### PR TITLE
Make changes to the sign-in / sign-up pages.

### DIFF
--- a/frontend/pages/admin/sign-in.tsx
+++ b/frontend/pages/admin/sign-in.tsx
@@ -14,6 +14,7 @@ import { useSnackbar } from 'notistack';
 import api from '../../frontendApis';
 import useAdminLoginCheck from '../../hooks/useAdminLogInCheck';
 import { AdminLoginData } from '../../types/admin';
+import { boxSx, h1Sx, mainSx, submitButtonSx } from '../../styles/admin/sign-in';
 
 const adminApi = api.admins;
 
@@ -60,19 +61,8 @@ const SignIn: NextPage = () => {
   };
 
   return (
-    <Container
-      component="main"
-      maxWidth="xs"
-      sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
-    >
-      <Box
-        sx={{
-          marginTop: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
+    <Container component="main" maxWidth="xs" sx={mainSx}>
+      <Box sx={boxSx}>
         <Stack component="div" direction="row" spacing={0.5}>
           <Typography variant={'h3'}>Giving Coupons</Typography>
 
@@ -80,7 +70,7 @@ const SignIn: NextPage = () => {
             Admin
           </Typography>
         </Stack>
-        <Typography component="h1" variant="h5" sx={{ mt: 2 }}>
+        <Typography component="h1" variant="h5" sx={h1Sx}>
           Sign in
         </Typography>
         <form onSubmit={formik.handleSubmit}>
@@ -92,7 +82,7 @@ const SignIn: NextPage = () => {
               <TextField required fullWidth label="Password" type="password" {...propHelper('password')} />
             </Grid>
           </Grid>
-          <Button type="submit" disabled={!formik.isValid} fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+          <Button type="submit" disabled={!formik.isValid} fullWidth variant="contained" sx={submitButtonSx}>
             Sign In
           </Button>
           <Grid container justifyContent="center">

--- a/frontend/pages/admin/sign-in.tsx
+++ b/frontend/pages/admin/sign-in.tsx
@@ -70,7 +70,7 @@ const SignIn: NextPage = () => {
             Admin
           </Typography>
         </Stack>
-        <Typography component="h1" variant="h5" sx={h1Sx}>
+        <Typography component="h1" variant="h4" sx={h1Sx}>
           Sign in
         </Typography>
         <form onSubmit={formik.handleSubmit}>

--- a/frontend/pages/admin/sign-in.tsx
+++ b/frontend/pages/admin/sign-in.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@mui/material';
 import Box from '@mui/material/Box';
+import * as Yup from 'yup';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
@@ -12,9 +13,14 @@ import { useRouter } from 'next/router';
 import { useSnackbar } from 'notistack';
 import api from '../../frontendApis';
 import useAdminLoginCheck from '../../hooks/useAdminLogInCheck';
-import { AdminLoginData, adminLoginDataSchema } from '../../types/admin';
+import { AdminLoginData } from '../../types/admin';
 
 const adminApi = api.admins;
+
+const adminLoginDataSchema = Yup.object({
+  username: Yup.string().required('Username is a required field.'),
+  password: Yup.string().required('Password is a required field.'),
+});
 
 const SignIn: NextPage = () => {
   useAdminLoginCheck();

--- a/frontend/pages/admin/sign-up.tsx
+++ b/frontend/pages/admin/sign-up.tsx
@@ -78,7 +78,7 @@ const SignUp: NextPage = () => {
             Admin
           </Typography>
         </Stack>
-        <Typography component="h1" variant="h5" sx={h1Sx}>
+        <Typography component="h1" variant="h4" sx={h1Sx}>
           Sign up
         </Typography>
         <form onSubmit={formik.handleSubmit}>

--- a/frontend/pages/admin/sign-up.tsx
+++ b/frontend/pages/admin/sign-up.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@mui/material';
 import Box from '@mui/material/Box';
+import * as Yup from 'yup';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
@@ -12,9 +13,20 @@ import { useRouter } from 'next/router';
 import { useSnackbar } from 'notistack';
 import api from '../../frontendApis';
 import useAdminLoginCheck from '../../hooks/useAdminLogInCheck';
-import { AdminPostData, adminPostDataSchema } from '../../types/admin';
+import { AdminPostData } from '../../types/admin';
 
 const adminApi = api.admins;
+
+const adminPostDataSchema = Yup.object({
+  username: Yup.string().required('Username is a required field.'),
+  password: Yup.string()
+    .required('Password is a required field.')
+    .min(6, `The new user's password must be at least 6 characters long.`),
+  passwordConfirmation: Yup.string()
+    .required('Password confirmation is a required field.')
+    .oneOf([Yup.ref('password'), null], 'Passwords must match'),
+  masterPassword: Yup.string().required('Master password is a required field.'),
+});
 
 const SignUp: NextPage = () => {
   useAdminLoginCheck();

--- a/frontend/pages/admin/sign-up.tsx
+++ b/frontend/pages/admin/sign-up.tsx
@@ -14,6 +14,7 @@ import { useSnackbar } from 'notistack';
 import api from '../../frontendApis';
 import useAdminLoginCheck from '../../hooks/useAdminLogInCheck';
 import { AdminPostData } from '../../types/admin';
+import { boxSx, h1Sx, mainSx, submitButtonSx } from '../../styles/admin/sign-up';
 
 const adminApi = api.admins;
 
@@ -68,19 +69,8 @@ const SignUp: NextPage = () => {
   };
 
   return (
-    <Container
-      component="main"
-      maxWidth="xs"
-      sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}
-    >
-      <Box
-        sx={{
-          marginTop: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
+    <Container component="main" maxWidth="xs" sx={mainSx}>
+      <Box sx={boxSx}>
         <Stack component="div" direction="row" spacing={0.5}>
           <Typography variant={'h3'}>Giving Coupons</Typography>
 
@@ -88,7 +78,7 @@ const SignUp: NextPage = () => {
             Admin
           </Typography>
         </Stack>
-        <Typography component="h1" variant="h5" sx={{ mt: 2 }}>
+        <Typography component="h1" variant="h5" sx={h1Sx}>
           Sign up
         </Typography>
         <form onSubmit={formik.handleSubmit}>
@@ -112,7 +102,7 @@ const SignUp: NextPage = () => {
               <TextField required fullWidth label="Master Password" type="password" {...propHelper('masterPassword')} />
             </Grid>
           </Grid>
-          <Button type="submit" disabled={!formik.isValid} fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+          <Button type="submit" disabled={!formik.isValid} fullWidth variant="contained" sx={submitButtonSx}>
             Sign Up
           </Button>
           <Grid container justifyContent="center">

--- a/frontend/styles/admin/sign-in/index.ts
+++ b/frontend/styles/admin/sign-in/index.ts
@@ -1,0 +1,1 @@
+export { mainSx, h1Sx, boxSx, submitButtonSx } from '../sign-up';

--- a/frontend/styles/admin/sign-up/index.ts
+++ b/frontend/styles/admin/sign-up/index.ts
@@ -1,0 +1,26 @@
+import { SxProps } from '@mui/material';
+
+// Note that for consistency, the styles in '../sign-in' take reference from these values.
+
+export const mainSx: SxProps = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+};
+
+export const boxSx: SxProps = {
+  marginTop: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+};
+
+export const h1Sx: SxProps = {
+  mt: 2,
+};
+
+export const submitButtonSx: SxProps = {
+  mt: 3,
+  mb: 2,
+};

--- a/frontend/styles/admin/sign-up/index.ts
+++ b/frontend/styles/admin/sign-up/index.ts
@@ -18,6 +18,7 @@ export const boxSx: SxProps = {
 
 export const h1Sx: SxProps = {
   mt: 2,
+  mb: 2,
 };
 
 export const submitButtonSx: SxProps = {

--- a/frontend/types/admin.ts
+++ b/frontend/types/admin.ts
@@ -1,26 +1,16 @@
-import { ref, object, string, InferType } from 'yup';
-
 export interface AdminData {
   id: number;
   username: string;
 }
 
-export const adminLoginDataSchema = object({
-  username: string().required('Username is a required field.'),
-  password: string().required('Password is a required field.'),
-});
+export type AdminLoginData = {
+  username: string;
+  password: string;
+};
 
-export type AdminLoginData = InferType<typeof adminLoginDataSchema>;
-
-export const adminPostDataSchema = object({
-  username: string().required('Username is a required field.'),
-  password: string()
-    .required('Password is a required field.')
-    .min(6, `The new user's password must be at least 6 characters long.`),
-  passwordConfirmation: string()
-    .required('Password confirmation is a required field.')
-    .oneOf([ref('password'), null], 'Passwords must match'),
-  masterPassword: string().required('Master password is a required field.'),
-});
-
-export type AdminPostData = InferType<typeof adminPostDataSchema>;
+export type AdminPostData = {
+  username: string;
+  password: string;
+  passwordConfirmation: string;
+  masterPassword: string;
+};


### PR DESCRIPTION
Closes #81 

- Refactor yup const from types/* to form page.
  - `yup.Schema` isn't a type, and they're only used in form
- Use style files instead of inline sx.
- Adjust spacing and size.

![telegram-cloud-photo-size-5-6206393679237722716-y](https://user-images.githubusercontent.com/7360964/194836144-67bce963-12f9-4a56-906c-1e8be1ad560a.jpg)
