### PR TITLE
Try to make url not break

### DIFF
--- a/frontend/components/coupons/Coupon.tsx
+++ b/frontend/components/coupons/Coupon.tsx
@@ -9,8 +9,7 @@ interface Props {
 }
 
 const Coupon = ({ coupon }: Props) => {
-  const websiteUrl = 'https://giving-coupons.sivarn.com/';
-  // const websiteUrl = process.env.NEXT_PUBLIC_BASE_CLIENT_URL;
+  const websiteUrl = process.env.NEXT_PUBLIC_BASE_CLIENT_URL;
   const redeemUrl = `${websiteUrl}/redeem/${coupon.urlToken}`;
 
   return (

--- a/frontend/components/coupons/Coupon.tsx
+++ b/frontend/components/coupons/Coupon.tsx
@@ -9,26 +9,29 @@ interface Props {
 }
 
 const Coupon = ({ coupon }: Props) => {
-  const websiteUrl = process.env.NEXT_PUBLIC_BASE_CLIENT_URL;
+  const websiteUrl = 'https://giving-coupons.sivarn.com/';
+  // const websiteUrl = process.env.NEXT_PUBLIC_BASE_CLIENT_URL;
   const redeemUrl = `${websiteUrl}/redeem/${coupon.urlToken}`;
 
   return (
     <Stack sx={couponContainerSx} component="div" direction="row">
       <Stack sx={leftSectionSx} component="div">
-        <Typography fontSize={120} fontWeight={800}>
+        <Typography fontSize={100} fontWeight={800}>
           ${coupon.denomination}
         </Typography>
 
-        <Typography gutterBottom align="center">
-          Donate ${coupon.denomination} to a charity of your choice for free
-        </Typography>
+        <Typography align="center">Donate ${coupon.denomination} to a charity of your choice for free</Typography>
 
         <Typography variant="caption" align="center">
           This was kindly sponsored by a donor through Giving Coupons.
         </Typography>
 
         <Typography variant="caption" align="center">
-          Find out more about how we spread the gift of giving at {websiteUrl}
+          Find out more about how we spread the gift of giving at
+        </Typography>
+
+        <Typography variant="caption" align="center" noWrap>
+          {websiteUrl}
         </Typography>
       </Stack>
 


### PR DESCRIPTION
Closes #203 

This fix (I fixed the left section) may not be worth it because our coupon design is going to change.

Also for long urls, unless our coupon is much longer, it has to wrap (notice the right section)

<img width="691" alt="Screenshot 2022-10-18 at 12 47 49 PM" src="https://user-images.githubusercontent.com/71375383/196337892-2905de77-faea-4d53-ad93-08367ebff944.png">

