### PR TITLE
Implement charity dialog

### DIFF
--- a/frontend/components/campaigns/campaignCharities/CampaignCharityDialog.tsx
+++ b/frontend/components/campaigns/campaignCharities/CampaignCharityDialog.tsx
@@ -1,0 +1,70 @@
+import LinkIcon from '@mui/icons-material/Link';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+import { charityLogoSx } from '../../../styles/components/charities/CampaignCharityCardStyles';
+import {
+  charityImageSx,
+  dialogActionsSx,
+  dialogContentSx,
+  dialogContentTextSx,
+  dialogTitleSx,
+} from '../../../styles/components/charities/CampaignCharityDialogStyles';
+import { CampaignCharityDonationPublicData } from '../../../types/campaignCharities';
+import Button from '../../generic/Button';
+
+interface Props {
+  campaignCharity: CampaignCharityDonationPublicData;
+  open: boolean;
+  handleClose: () => void;
+}
+
+const CampaignCharityDialog = ({ campaignCharity, open, handleClose }: Props) => {
+  const theme = useTheme();
+  const router = useRouter();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  return (
+    <Dialog fullScreen={isMobile} maxWidth="md" open={open} onClose={handleClose}>
+      <DialogTitle sx={dialogTitleSx}>
+        <Stack component="div" direction="row" spacing={2} alignItems="center">
+          <Box sx={charityLogoSx} component="img" src={campaignCharity.charity.logoBase64} />
+
+          <Typography variant="h2">{campaignCharity.charity.name}</Typography>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent sx={dialogContentSx}>
+        <Box sx={charityImageSx} component="img" src={campaignCharity.charity.imageBase64} />
+
+        <Typography sx={dialogContentTextSx}>{campaignCharity.charity.description}</Typography>
+      </DialogContent>
+
+      <DialogActions sx={dialogActionsSx}>
+        <Button
+          actionType="mutedWithoutOutline"
+          size="small"
+          startIcon={<LinkIcon />}
+          onClick={() => router.push(campaignCharity.charity.websiteUrl)}
+        >
+          Vist Page
+        </Button>
+
+        <Button actionType="mutedWithoutOutline" size="small" onClick={handleClose}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CampaignCharityDialog;

--- a/frontend/components/generic/Button.tsx
+++ b/frontend/components/generic/Button.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Map } from 'immutable';
 
 interface Props extends MuiButtonProps {
-  actionType: 'primary' | 'secondary' | 'tertiary' | 'muted' | 'danger';
+  actionType: 'primary' | 'secondary' | 'tertiary' | 'muted' | 'mutedWithoutOutline' | 'danger';
   // Note: Using this because of https://github.com/mui/material-ui/issues/16846
   isLabel?: boolean;
 }
@@ -24,6 +24,10 @@ const buttonPropsMap = Map<Props['actionType'], Omit<Props, 'actionType'>>({
   muted: {
     color: 'neutral',
     variant: 'outlined',
+  },
+  mutedWithoutOutline: {
+    color: 'neutral',
+    variant: 'text',
   },
   danger: {
     color: 'error',

--- a/frontend/styles/components/charities/CampaignCharityDialogStyles.ts
+++ b/frontend/styles/components/charities/CampaignCharityDialogStyles.ts
@@ -1,0 +1,21 @@
+import { SxProps } from '@mui/material';
+
+export const dialogTitleSx: SxProps = {
+  padding: '10px',
+};
+
+export const dialogContentSx: SxProps = { padding: 0 };
+
+export const dialogContentTextSx: SxProps = { padding: '10px' };
+
+export const dialogActionsSx: SxProps = { justifyContent: 'space-between' };
+
+export const charityLogoSx: SxProps = {
+  maxHeight: '40px',
+  minHeight: '40px',
+  height: '40px',
+};
+
+export const charityImageSx: SxProps = {
+  width: '100%',
+};


### PR DESCRIPTION
<img width="421" alt="Screenshot 2022-10-21 at 10 49 25 PM" src="https://user-images.githubusercontent.com/53614454/197225580-05808967-2a3d-421a-a0cc-97cc33174c94.png">

<img width="1056" alt="Screenshot 2022-10-21 at 10 49 02 PM" src="https://user-images.githubusercontent.com/53614454/197225674-d3f8062f-1570-45f3-aef3-5b558bfe32dd.png">

In mobile, dialog is fullscreen as it looks ugly otherwise. 

Changed the design a bit to make it easier to use the dialog mui component. Let me know if I should follow the figma more closely