### PR TITLE
Allow campaigns to be created in the past (admin console only).

### DIFF
--- a/frontend/components/campaigns/form/CampaignForm.tsx
+++ b/frontend/components/campaigns/form/CampaignForm.tsx
@@ -76,7 +76,7 @@ const CampaignForm = ({
 
               <FormDatePicker name="start" label="Start Date" />
 
-              <FormDatePicker name="end" label="End Date" />
+              <FormDatePicker name="end" label="End Date" minDate={values.start ?? undefined} />
 
               <FormImageUpload name="imageBase64" label="Upload Campaign Image" />
             </Stack>

--- a/frontend/components/forms/FormDatePicker.tsx
+++ b/frontend/components/forms/FormDatePicker.tsx
@@ -1,7 +1,7 @@
 import { TextField, useMediaQuery } from '@mui/material';
 import { DesktopDatePicker, MobileDatePicker } from '@mui/x-date-pickers';
 import { Nullable } from '../../types/utils';
-import moment, { Moment } from 'moment';
+import { Moment } from 'moment';
 import { useTheme } from '@mui/system';
 import React from 'react';
 import { MuiTextFieldProps } from '@mui/x-date-pickers/internals';
@@ -11,9 +11,10 @@ import { DATE_FORMAT } from '../../utils/constants';
 interface Props {
   name: string;
   label: string;
+  minDate?: Moment | undefined;
 }
 
-const FormDatePicker = ({ name, label }: Props) => {
+const FormDatePicker = ({ name, label, minDate }: Props) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [, { error, touched, value }, { setTouched, setValue }] = useField(name);
@@ -21,8 +22,8 @@ const FormDatePicker = ({ name, label }: Props) => {
   const innerProps = {
     label,
     value,
+    minDate,
     inputFormat: DATE_FORMAT,
-    minDate: moment().add(1, 'day').startOf('day'),
     onChange: (value: Nullable<Moment>) => {
       const corrected = value === null ? value : value.startOf('day');
       // It is not explicitly stated in the docs / types, but it appears setFieldValue is an

--- a/frontend/components/interests/form/InterestForm.tsx
+++ b/frontend/components/interests/form/InterestForm.tsx
@@ -106,7 +106,7 @@ export default function InterestForm({ onSubmit }: InterestFormProps) {
                   minRows={2}
                 />
 
-                <FormDatePicker name="start" label={'Start Date'} />
+                <FormDatePicker name="start" label={'Start Date'} minDate={moment().add(1, 'day').startOf('day')} />
 
                 <FormTextInput
                   name="lengthOfCampaign"

--- a/frontend/pages/admin/campaigns/create.tsx
+++ b/frontend/pages/admin/campaigns/create.tsx
@@ -57,8 +57,7 @@ const createCampaignSchema = Yup.object().shape(
       .typeError('Start date must be a date.')
       .when('end', (endDate, schema) =>
         isValidDate(endDate) ? schema.max(endDate, 'Start date cannot be after End date') : schema,
-      )
-      .min(moment().endOf('day'), 'Start date cannot be today or in the past.'),
+      ),
     end: Yup.date()
       .required('End date is required.')
       .typeError('End date must be a date.')


### PR DESCRIPTION
Fixes #257

- Makes minDate a customisable prop for date picker.
- Allow past start dates in campaign create.
