### PR TITLE
Fix graph ends

### DIFF
--- a/frontend/components/charts/CompetingGraph.tsx
+++ b/frontend/components/charts/CompetingGraph.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import { Box, Stack, SxProps } from '@mui/system';
 import {
   bottomGraphLegendSx,
+  emptyBarSx,
   graphLabelSx,
   leftBarSx,
   rightBarSx,
@@ -27,6 +28,8 @@ const CompetingGraph = ({
   barFractions,
   overrideGraphSx = [],
 }: Props) => {
+  const fakeOffsetFraction = 1 / 25;
+
   return (
     <Stack component="div" spacing={0.5}>
       <Box sx={topGraphLegendSx}>
@@ -43,15 +46,35 @@ const CompetingGraph = ({
         ))}
       </Box>
 
-      {barFractions[0] !== null && barFractions[1] !== null ? (
+      {barFractions[0] === null && barFractions[1] === null && (
+        <HorizontalBarGraph bars={[{ fraction: 1 }]} overrideGraphSx={overrideGraphSx} />
+      )}
+
+      {barFractions[0] === 0 && barFractions[1] !== null && (
+        <HorizontalBarGraph
+          bars={[{ fraction: fakeOffsetFraction }, { fraction: barFractions[1] - fakeOffsetFraction }]}
+          overrideFirstBarSx={emptyBarSx}
+          overrideLastBarSx={rightBarSx}
+          overrideGraphSx={overrideGraphSx}
+        />
+      )}
+
+      {barFractions[1] === 0 && barFractions[0] !== null && (
+        <HorizontalBarGraph
+          bars={[{ fraction: barFractions[0] - fakeOffsetFraction }, { fraction: fakeOffsetFraction }]}
+          overrideFirstBarSx={leftBarSx}
+          overrideLastBarSx={emptyBarSx}
+          overrideGraphSx={overrideGraphSx}
+        />
+      )}
+
+      {barFractions[0] !== 0 && barFractions[0] !== null && barFractions[1] !== 0 && barFractions[1] !== null && (
         <HorizontalBarGraph
           bars={[{ fraction: barFractions[0] }, { fraction: barFractions[1] }]}
           overrideFirstBarSx={leftBarSx}
           overrideLastBarSx={rightBarSx}
           overrideGraphSx={overrideGraphSx}
         />
-      ) : (
-        <HorizontalBarGraph bars={[{ fraction: 1 }]} overrideGraphSx={overrideGraphSx} />
       )}
 
       <Box sx={bottomGraphLegendSx}>

--- a/frontend/components/charts/SmallCompetingGraph.tsx
+++ b/frontend/components/charts/SmallCompetingGraph.tsx
@@ -5,6 +5,7 @@ import {
   graphLegendSx,
   leftBarSx,
   rightBarSx,
+  emptyBarSx,
 } from '../../styles/components/charts/SmallCompetingGraphStyles';
 import { Nullable } from '../../types/utils';
 import HorizontalBarGraph from './HorizontalBarGraph';
@@ -17,17 +18,39 @@ interface Props {
 }
 
 const SmallCompetingGraph = ({ leftLabel, rightLabel, barFractions, overrideGraphSx = [] }: Props) => {
+  const fakeOffsetFraction = 1 / 25;
+
   return (
     <Stack component="div">
-      {barFractions[0] !== null && barFractions[1] !== null ? (
+      {barFractions[0] === null && barFractions[1] === null && (
+        <HorizontalBarGraph bars={[{ fraction: 1 }]} overrideGraphSx={overrideGraphSx} />
+      )}
+
+      {barFractions[0] === 0 && barFractions[1] !== null && (
+        <HorizontalBarGraph
+          bars={[{ fraction: fakeOffsetFraction }, { fraction: barFractions[1] - fakeOffsetFraction }]}
+          overrideFirstBarSx={emptyBarSx}
+          overrideLastBarSx={rightBarSx}
+          overrideGraphSx={overrideGraphSx}
+        />
+      )}
+
+      {barFractions[1] === 0 && barFractions[0] !== null && (
+        <HorizontalBarGraph
+          bars={[{ fraction: barFractions[0] - fakeOffsetFraction }, { fraction: fakeOffsetFraction }]}
+          overrideFirstBarSx={leftBarSx}
+          overrideLastBarSx={emptyBarSx}
+          overrideGraphSx={overrideGraphSx}
+        />
+      )}
+
+      {barFractions[0] !== 0 && barFractions[0] !== null && barFractions[1] !== 0 && barFractions[1] !== null && (
         <HorizontalBarGraph
           bars={[{ fraction: barFractions[0] }, { fraction: barFractions[1] }]}
           overrideFirstBarSx={leftBarSx}
           overrideLastBarSx={rightBarSx}
           overrideGraphSx={overrideGraphSx}
         />
-      ) : (
-        <HorizontalBarGraph bars={[{ fraction: 1 }]} overrideGraphSx={overrideGraphSx} />
       )}
 
       <Box sx={graphLegendSx}>

--- a/frontend/styles/components/charts/CompetingGraphStyles.ts
+++ b/frontend/styles/components/charts/CompetingGraphStyles.ts
@@ -26,3 +26,7 @@ export const leftBarSx: SxProps = {
 export const rightBarSx: SxProps = {
   backgroundColor: theme.palette.secondaryTranslucent.main,
 };
+
+export const emptyBarSx: SxProps = {
+  backgroundColor: theme.palette.neutral.light,
+};

--- a/frontend/styles/components/charts/SmallCompetingGraphStyles.ts
+++ b/frontend/styles/components/charts/SmallCompetingGraphStyles.ts
@@ -17,3 +17,7 @@ export const leftBarSx: SxProps = {
 export const rightBarSx: SxProps = {
   backgroundColor: theme.palette.secondaryTranslucent.main,
 };
+
+export const emptyBarSx: SxProps = {
+  backgroundColor: theme.palette.neutral.light,
+};


### PR DESCRIPTION
Closes #281 

The $0 side can look nicer by making it curved + having the empty color. Giving it some fake offset allows people to tell which side the colored graph belongs to more easily

Note: I'm writing the conditions out instead of using boolean variables so that typescript does not complain.

<img width="484" alt="Screenshot 2022-10-26 at 2 48 21 PM" src="https://user-images.githubusercontent.com/71375383/197954687-5516585b-126c-4b72-91ee-36e50d4199e8.png">
<img width="352" alt="Screenshot 2022-10-26 at 2 48 39 PM" src="https://user-images.githubusercontent.com/71375383/197954701-1607206b-def8-49a2-9f3c-6f419b897e60.png">

