### PR TITLE
Ensure that amount is a nullable number.

### DIFF
--- a/frontend/pages/redeem/[urlToken]/index.tsx
+++ b/frontend/pages/redeem/[urlToken]/index.tsx
@@ -37,6 +37,9 @@ import { DEFAULT_SECONDARY_DONATION_VALUE } from '../../../utils/constants';
 const validationSchema = Yup.object().shape({
   campaignCharityId: Yup.number().required('Campaign charity is required'),
   amount: Yup.number()
+    // Ensure falsey values like 0 and empty string are set to null.
+    // This is necessary for the min check and because text input can return "".
+    .transform((newValue) => newValue || null)
     .nullable()
     .typeError('Amount must be a number')
     .integer('Only dollar amounts are accepted')
@@ -259,8 +262,7 @@ const Redeem: NextPage = () => {
                           updateRedemptionStep(
                             redemptionState?.current ?? RedemptionStep.SELECT_CHARITY,
                             formikValues.campaignCharityId,
-                            // Empty string check as the FormTextInput component will return '' in some circumstances.
-                            formikValues.amount === '' ? 0 : formikValues.amount,
+                            formikValues.amount,
                           );
                         } else {
                           // If form has not been touched and there is no matching redemption state in cookie, do nothing.

--- a/frontend/pages/redeem/[urlToken]/index.tsx
+++ b/frontend/pages/redeem/[urlToken]/index.tsx
@@ -259,7 +259,8 @@ const Redeem: NextPage = () => {
                           updateRedemptionStep(
                             redemptionState?.current ?? RedemptionStep.SELECT_CHARITY,
                             formikValues.campaignCharityId,
-                            formikValues.amount,
+                            // Empty string check as the FormTextInput component will return '' in some circumstances.
+                            formikValues.amount === '' ? 0 : formikValues.amount,
                           );
                         } else {
                           // If form has not been touched and there is no matching redemption state in cookie, do nothing.


### PR DESCRIPTION
To test, when redeeming a coupon, type in a value as personal contribution and then delete all text in that personal contribution text field. Then continue on and try to submit. In master it will have an error when trying to complete the process. In this branch, it should be fixed.

Fixes #355 

----

FormTextInput can be allowed to return "", which rather than treating as
invalid, should be maintained as 0.

We should not require users to type in 0 in this situation, and it is
also not helpful to create a transformer to ensure this is the case. If
this is not appropriate, consider creating a FormNumericTextInput
component instead of modifying FormTextInput.


