### PR TITLE
Update css for charity logos in campaign card.

### DIFF
--- a/frontend/styles/components/campaigns/list/CampaignListCardStyles.ts
+++ b/frontend/styles/components/campaigns/list/CampaignListCardStyles.ts
@@ -19,6 +19,7 @@ export const descriptionContainerSx: SxProps = {
 };
 
 export const charityLogoSx: SxProps = {
+  objectFit: 'contain',
   width: '80%',
   aspectRatio: '1 / 1',
 };

--- a/frontend/styles/components/charities/CampaignCharityAccordionCardStyles.ts
+++ b/frontend/styles/components/charities/CampaignCharityAccordionCardStyles.ts
@@ -20,6 +20,7 @@ export const graphSx: SxProps = {
 };
 
 export const charityLogoSx: SxProps = {
+  objectFit: 'contain',
   margin: 1,
   maxHeight: '40px',
   minHeight: '40px',

--- a/frontend/styles/components/charities/CampaignCharityCardStyles.ts
+++ b/frontend/styles/components/charities/CampaignCharityCardStyles.ts
@@ -20,6 +20,7 @@ export const graphSx: SxProps = {
 };
 
 export const charityLogoSx: SxProps = {
+  objectFit: 'contain',
   margin: 1,
   maxHeight: '40px',
   minHeight: '40px',

--- a/frontend/styles/components/redeem/ReceiptStyles.ts
+++ b/frontend/styles/components/redeem/ReceiptStyles.ts
@@ -11,6 +11,7 @@ export const headerSx: SxProps = {
 };
 
 export const imageSx: SxProps = {
+  objectFit: 'contain',
   padding: '10px',
   borderRadius: '15px',
   minHeight: '40px',


### PR DESCRIPTION
Fixes #425


# All Campaigns Page

Old:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/7360964/200227320-cf139892-c29d-4533-a7b6-87e61c5a62ec.png">

New:
<img width="948" alt="image" src="https://user-images.githubusercontent.com/7360964/200227328-7218c628-c477-485e-817a-a9684ac4bcef.png">

# Campaign Page 

Old:
<img width="307" alt="image" src="https://user-images.githubusercontent.com/7360964/200227718-db33c1e3-03b4-4221-9959-e92a340a05cb.png">

New:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/7360964/200227737-b79e34d7-c9d8-4413-bbae-7d4e7898274e.png">

# Redeem charity dialog / charity card

Old:
<img width="598" alt="image" src="https://user-images.githubusercontent.com/7360964/200228441-72ca7dee-afea-4c88-a9a5-75c9ff12fb0d.png">
<img width="739" alt="image" src="https://user-images.githubusercontent.com/7360964/200228387-0928294b-0f65-40be-a23b-716e233e0813.png">

New:
<img width="610" alt="image" src="https://user-images.githubusercontent.com/7360964/200228492-f5038c08-6af6-4c8c-9009-f790f4a6ded0.png">
<img width="785" alt="image" src="https://user-images.githubusercontent.com/7360964/200228505-a0afb757-7b95-4be9-b6c1-ac441a22421d.png">


# Receipts

Old:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/7360964/200228818-da4bb1b3-4fd9-4b16-bd01-0c62c78054b3.png">

New:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/7360964/200228835-7acda8eb-3d81-4b72-86ad-f978cff4c5de.png">


