### PR TITLE
Fix multi paragraph descriptions.

### DIFF
--- a/frontend/components/campaigns/CampaignDescription.tsx
+++ b/frontend/components/campaigns/CampaignDescription.tsx
@@ -18,9 +18,11 @@ export default function CampaignDescription({ campaign }: Props) {
       <Stack>
         <Quotes variant="open" />
 
-        <Typography variant="body1" align="center" color="contrast.dark">
-          {campaign.description}
-        </Typography>
+        {campaign.description.split('\n').map((paragraph, index) => (
+          <Typography variant="body1" align="center" color="contrast.dark" gutterBottom key={index}>
+            {paragraph}
+          </Typography>
+        ))}
 
         <Quotes variant="close" sxProps={closeQuotesProps} />
       </Stack>

--- a/frontend/components/campaigns/campaignCharities/CampaignCharityAccordionCard.tsx
+++ b/frontend/components/campaigns/campaignCharities/CampaignCharityAccordionCard.tsx
@@ -86,9 +86,11 @@ const CampaignCharityAccordionCard = ({ campaignCharity }: Props) => {
 
           <Box sx={charityImageSx} component="img" src={campaignCharity.charity.imageUrl} />
 
-          <Typography variant="body2" sx={charityDescriptionSx}>
-            {campaignCharity.charity.description}
-          </Typography>
+          {campaignCharity.charity.description.split('\n').map((paragraph, index) => (
+            <Typography variant="body2" sx={charityDescriptionSx} gutterBottom key={index}>
+              {paragraph}
+            </Typography>
+          ))}
 
           <Divider />
 

--- a/frontend/components/campaigns/campaignCharities/CampaignCharityDialog.tsx
+++ b/frontend/components/campaigns/campaignCharities/CampaignCharityDialog.tsx
@@ -52,7 +52,13 @@ const CampaignCharityDialog = ({ campaignCharity, open, handleClose }: Props) =>
           src={campaignCharity.charity.imageUrl}
         />
 
-        <Typography sx={dialogContentTextSx}>{campaignCharity.charity.description}</Typography>
+        <Box sx={dialogContentTextSx}>
+          {campaignCharity.charity.description.split('\n').map((paragraph, index) => (
+            <Typography gutterBottom key={index}>
+              {paragraph}
+            </Typography>
+          ))}
+        </Box>
       </DialogContent>
 
       <DialogActions>

--- a/frontend/components/campaigns/dashboard/CampaignInfoCard.tsx
+++ b/frontend/components/campaigns/dashboard/CampaignInfoCard.tsx
@@ -63,7 +63,11 @@ const CampaignInfoCard = ({ campaign }: Props) => {
             </Stack>
           </Stack>
 
-          <Typography variant="body2">{campaign.description}</Typography>
+          {campaign.description.split('\n').map((paragraph, index) => (
+            <Typography variant="body2" gutterBottom key={index}>
+              {paragraph}
+            </Typography>
+          ))}
 
           <Stack sx={campaignInfoItemSx} component="div" spacing={1}>
             <Typography variant="h4">Status: {getCampaignStatus(campaign.start, campaign.end)}</Typography>

--- a/frontend/components/campaigns/dashboard/CampaignPublicInfoCard.tsx
+++ b/frontend/components/campaigns/dashboard/CampaignPublicInfoCard.tsx
@@ -51,7 +51,11 @@ const CampaignPublicInfoCard = ({ campaign }: Props) => {
           <Typography variant="h1">{campaign.name}</Typography>
         </Stack>
 
-        <Typography>{campaign.description}</Typography>
+        {campaign.description.split('\n').map((paragraph, index) => (
+          <Typography gutterBottom key={index}>
+            {paragraph}
+          </Typography>
+        ))}
       </Grid>
 
       <Grid item xs={12} md={6}>

--- a/frontend/components/campaigns/list/CampaignListCard.tsx
+++ b/frontend/components/campaigns/list/CampaignListCard.tsx
@@ -54,9 +54,11 @@ const CampaignListCard = ({ campaign }: Props) => {
         ))}
       </Grid>
 
-      <Typography sx={descriptionSx} variant="caption">
-        {campaign.description}
-      </Typography>
+      {campaign.description.split('\n').map((paragraph, index) => (
+        <Typography sx={descriptionSx} variant="caption" gutterBottom key={index}>
+          {paragraph}
+        </Typography>
+      ))}
     </Stack>
   );
 


### PR DESCRIPTION
Fixes #441 

Multiline paragraphs pretended to be a single wall of text. I tried to fix it: (there are more than 2 fixes, but I got tired of ss.

Old:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/7360964/200361250-dab6028d-3088-453a-bce0-612090611e42.png">
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/7360964/200361269-7f1769ff-8251-4eea-9a61-c0a862e0d3ab.png">


New:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/7360964/200361217-fccc7c87-f47a-46bc-a515-55aef1c03a1a.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/7360964/200361232-306bb669-02c1-4424-abc0-aed2b26a3b91.png">
